### PR TITLE
feat: key renamed

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -2,11 +2,23 @@ import { NextRequest, NextResponse } from "next/server";
 import { test, expect } from "vitest";
 
 import { type Middleware } from "../src/types";
-import { addParams, findMiddleware, getParams } from "../src/utils";
+import {
+    addParams,
+    findMiddleware,
+    getParams,
+    RequestParser,
+} from "../src/utils";
 
-const queryForDomain = { domain: "app.acme.org", path: "/" };
+const queryForHostname: ReturnType<RequestParser> = {
+    hostname: "app.acme.org",
+    path: "/",
+};
 
-const queryForPath = { domain: "", path: "/dashboard/it" };
+const queryForPath: ReturnType<RequestParser> = {
+    hostname: "",
+    path: "/dashboard/it",
+};
+
 const middlewares: Middleware<unknown>[] = [
     {
         path: "/dashboard/:lang",
@@ -75,24 +87,24 @@ test("should find the middleware with string", () => {
     const middleware = findMiddleware(middlewares, queryForPath);
 
     expect(middleware).not.toBeUndefined();
-    expect(middleware).toHaveProperty("matcher");
+    expect(middleware).toHaveProperty("path");
 
     if (!middleware?.path) return;
 
     expect(middleware.filter?.({ lang: "it" })).toBe(true);
 
-    const m2 = findMiddleware(middlewares, queryForDomain);
+    const m2 = findMiddleware(middlewares, queryForHostname);
 
     expect(m2).not.toBeUndefined();
-    expect(m2).not.toHaveProperty("matcher");
-    expect(m2).toHaveProperty("domain");
+    expect(m2).not.toHaveProperty("path");
+    expect(m2).toHaveProperty("hostname");
 });
 
 test("should retrive the params", () => {
     const middleware = findMiddleware(middlewares, queryForPath);
 
     expect(middleware).not.toBeUndefined();
-    expect(middleware).toHaveProperty("matcher");
+    expect(middleware).toHaveProperty("path");
 
     if (!middleware?.path) return;
 
@@ -106,7 +118,7 @@ test("should add the params", () => {
     const middleware = findMiddleware(middlewares, queryForPath);
 
     expect(middleware).not.toBeUndefined();
-    expect(middleware).toHaveProperty("matcher");
+    expect(middleware).toHaveProperty("path");
 
     if (!middleware?.path) return;
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,6 +1,7 @@
-import { UrlParams } from "@/types";
 import { NextRequest } from "next/server";
 import { test, expect } from "vitest";
+
+import { UrlParams } from "@/types";
 
 import { parse, replaceValues } from "../src/utils";
 
@@ -12,7 +13,7 @@ test("should parse next url", () => {
 
     expect(data).toStrictEqual({
         path: "/",
-        domain: "google.com",
+        hostname: "google.com",
     });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ devDependencies:
   eslint-import-resolver-typescript: 3.5.2_mynvxvmq5qtyojffiqgev4x7mm
   eslint-plugin-import: 2.26.0_goironxpvhcmocjenyhcuwtawi
   eslint-plugin-unused-imports: 2.0.0_ajidtrfjdn3twdrkbqcn2yjcxu
-  next: 13.0.6_biqbaboplfbrettd7655fr4n2y
+  next: 13.0.6
   prettier: 2.7.1
   tsup: 6.3.0_typescript@4.8.4
   typescript: 4.8.4
@@ -1782,10 +1782,6 @@ packages:
     resolution: {integrity: sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==}
     dev: true
 
-  /js-tokens/4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    dev: true
-
   /js-yaml/4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -1848,13 +1844,6 @@ packages:
 
   /lodash.sortby/4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
-    dev: true
-
-  /loose-envify/1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
-    hasBin: true
-    dependencies:
-      js-tokens: 4.0.0
     dev: true
 
   /loupe/2.3.4:
@@ -1939,7 +1928,7 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /next/13.0.6_biqbaboplfbrettd7655fr4n2y:
+  /next/13.0.6:
     resolution: {integrity: sha512-COvigvms2LRt1rrzfBQcMQ2GZd86Mvk1z+LOLY5pniFtL4VrTmhZ9salrbKfSiXbhsD01TrDdD68ec3ABDyscA==}
     engines: {node: '>=14.6.0'}
     hasBin: true
@@ -1961,9 +1950,7 @@ packages:
       '@swc/helpers': 0.4.14
       caniuse-lite: 1.0.30001436
       postcss: 8.4.14
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      styled-jsx: 5.1.0_react@18.2.0
+      styled-jsx: 5.1.0
     optionalDependencies:
       '@next/swc-android-arm-eabi': 13.0.6
       '@next/swc-android-arm64': 13.0.6
@@ -2195,23 +2182,6 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
-  /react-dom/18.2.0_react@18.2.0:
-    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
-    peerDependencies:
-      react: ^18.2.0
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.2.0
-      scheduler: 0.23.0
-    dev: true
-
-  /react/18.2.0:
-    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      loose-envify: 1.4.0
-    dev: true
-
   /readdirp/3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -2289,12 +2259,6 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.1.3
       is-regex: 1.1.4
-    dev: true
-
-  /scheduler/0.23.0:
-    resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
-    dependencies:
-      loose-envify: 1.4.0
     dev: true
 
   /semver/6.3.0:
@@ -2409,7 +2373,7 @@ packages:
       acorn: 8.8.1
     dev: true
 
-  /styled-jsx/5.1.0_react@18.2.0:
+  /styled-jsx/5.1.0:
     resolution: {integrity: sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -2423,7 +2387,6 @@ packages:
         optional: true
     dependencies:
       client-only: 0.0.1
-      react: 18.2.0
     dev: true
 
   /sucrase/3.28.0:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { NextMiddleware, NextRequest, NextResponse } from "next/server";
-import { match, P } from "ts-pattern";
 
 import { Middleware, NextRequestWithParams, RedirectMatcher } from "./types";
 import {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,16 @@
 import { NextMiddleware, NextRequest, NextResponse } from "next/server";
+import { match, P } from "ts-pattern";
 
 import { Middleware, NextRequestWithParams, RedirectMatcher } from "./types";
 import {
-    parse,
+    parse as defaultParser,
     findMiddleware,
     addParams,
     getParamsDescriptor,
     replaceValues,
     inject,
 } from "./utils";
+import { type RequestParser } from "./utils";
 
 export type {
     Middleware,
@@ -19,115 +21,121 @@ export type {
 interface WayfinderOptions<T> {
     debug?: boolean;
     injector?: (request: NextRequestWithParams<unknown>) => Promise<T> | T;
+    parser?: RequestParser;
 }
 
-export const getDomain = (request: NextRequest) => parse(request).domain;
+export const getHost = (request: NextRequest) =>
+    defaultParser(request).hostname;
 
 export function handlePaths<T>(
     middlewares: Middleware<T>[],
     options?: WayfinderOptions<T>
 ): NextMiddleware {
-    return async function (req, ev) {
-        const { path, domain } = parse(req);
-        const middleware = findMiddleware(middlewares, { path, domain });
+    return async function(req, ev) {
+        const parseRequest = options?.parser ?? defaultParser;
+
+        // extract the hostname and path from the request
+        const { path, hostname } = parseRequest(req);
+
+        // find the middleware corrisponding to the path or domain
+        const middleware = findMiddleware(middlewares, {
+            path,
+            hostname,
+        });
 
         if (options?.debug) {
             console.debug(`Middleware ${!middleware ? "Not " : ""}Found!`);
             if (middleware) console.debug(middleware);
         }
 
-        if (middleware) {
-            if (RedirectMatcher.is(middleware)) {
+        // if no middleware is found then continue the response pipe
+        if (!middleware) {
+            return NextResponse.next();
+        }
+
+        if (RedirectMatcher.is(middleware)) {
+            const requestWithParams = addParams<T>(req, middleware.path, path);
+
+            const pathname =
+                middleware.redirectTo instanceof Function
+                    ? middleware.redirectTo(requestWithParams)
+                    : replaceValues(
+                        middleware.redirectTo,
+                        requestWithParams.params
+                    );
+            const url = requestWithParams.nextUrl.clone();
+            url.pathname = pathname;
+
+            if (middleware.includeOrigin) {
+                url.searchParams.set(
+                    middleware.includeOrigin === true
+                        ? "origin"
+                        : middleware.includeOrigin,
+                    requestWithParams.nextUrl.pathname
+                );
+            }
+
+            return NextResponse.redirect(url);
+        }
+
+        // if the middleware handler is a function
+        // we suppose it is a NextMiddleware or NextMiddlewareWithParams
+        if (middleware.handler instanceof Function) {
+            if (middleware.path) {
+                // if is a path middleware
+                // add params to the request
                 const requestWithParams = addParams<T>(
                     req,
-                    middleware.matcher,
+                    middleware.path,
                     path
                 );
 
-                const pathname =
-                    middleware.redirectTo instanceof Function
-                        ? middleware.redirectTo(requestWithParams)
-                        : replaceValues(
-                              middleware.redirectTo,
-                              requestWithParams.params
-                          );
-                const url = requestWithParams.nextUrl.clone();
-                url.pathname = pathname;
+                if (middleware.pre) {
+                    const result = await middleware.pre(requestWithParams);
 
-                if (middleware.includeOrigin) {
-                    url.searchParams.set(
-                        middleware.includeOrigin === true
-                            ? "origin"
-                            : middleware.includeOrigin,
-                        requestWithParams.nextUrl.pathname
-                    );
-                }
+                    if (result !== true) {
+                        if (!result) return NextResponse.next();
 
-                return NextResponse.redirect(url);
-            }
+                        if (typeof result.redirectTo === "string") {
+                            const url = requestWithParams.nextUrl.clone();
+                            url.pathname = result.redirectTo;
 
-            // if the middleware handler is a function
-            // we suppose it is a NextMiddleware or NextMiddlewareWithParams
-            if (middleware.handler instanceof Function) {
-                if (middleware.matcher) {
-                    // if is a path middleware
-                    // add params to the request
-                    const requestWithParams = addParams<T>(
-                        req,
-                        middleware.matcher,
-                        path
-                    );
-
-                    if (middleware.pre) {
-                        const result = await middleware.pre(requestWithParams);
-
-                        if (result !== true) {
-                            if (!result) return NextResponse.next();
-
-                            if (typeof result.redirectTo === "string") {
-                                const url = requestWithParams.nextUrl.clone();
-                                url.pathname = result.redirectTo;
-
-                                return NextResponse.redirect(url, {
-                                    status: result.statusCode,
-                                });
-                            }
-
-                            return NextResponse.redirect(
-                                new URL(
-                                    result.redirectTo,
-                                    requestWithParams.nextUrl
-                                ),
-                                {
-                                    status: result.statusCode,
-                                }
-                            );
+                            return NextResponse.redirect(url, {
+                                status: result.statusCode,
+                            });
                         }
+
+                        return NextResponse.redirect(
+                            new URL(
+                                result.redirectTo,
+                                requestWithParams.nextUrl
+                            ),
+                            {
+                                status: result.statusCode,
+                            }
+                        );
                     }
-
-                    return middleware.handler(requestWithParams, ev);
                 }
 
-                // on domain we can't add any param
-                Object.defineProperty(req, "params", getParamsDescriptor({}));
-
-                if (options?.injector) {
-                    const data = await options.injector(
-                        req as unknown as NextRequestWithParams<unknown>
-                    );
-
-                    inject<T>(data)(req as NextRequestWithParams<unknown>);
-                }
-
-                return middleware.handler(req as NextRequestWithParams<T>, ev);
+                return middleware.handler(requestWithParams, ev);
             }
 
-            // if the handler is an array of middlewares
-            // then use recursion to handle them
-            return handlePaths(middleware.handler, options)(req, ev);
+            // on domain we can't add any param
+            Object.defineProperty(req, "params", getParamsDescriptor({}));
+
+            if (options?.injector) {
+                const data = await options.injector(
+                    req as unknown as NextRequestWithParams<unknown>
+                );
+
+                inject<T>(data)(req as NextRequestWithParams<unknown>);
+            }
+
+            return middleware.handler(req as NextRequestWithParams<T>, ev);
         }
 
-        // if no middleware is found then continue the response pipe
-        return NextResponse.next();
+        // if the handler is an array of middlewares
+        // then use recursion to handle them
+        return handlePaths(middleware.handler, options)(req, ev);
     };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { NextMiddleware, NextFetchEvent, NextRequest } from "next/server";
+import { Path } from "path-to-regexp";
 import { RequireExactlyOne } from "type-fest";
 
 export type UrlParams = Record<string, string | string[] | undefined>;
@@ -13,35 +14,109 @@ export type NextMiddlewareWithParams<T> = (
     event: NextFetchEvent
 ) => ReturnType<NextMiddleware>;
 
-export type PathMatcher = string | string[] | RegExp;
+/**
+ *
+ * Supported `path-to-regexp` input types.
+ */
+export type PathMatcher = Path;
 
 type MaybePromise<T> = T | Promise<T>;
 
 export type Middleware<T> =
     | RequireExactlyOne<
-          {
-              handler: NextMiddlewareWithParams<T> | Middleware<T>[];
-              domain?: RegExp | ((domain: string) => boolean);
-              matcher?: PathMatcher;
-              guard?: (params: UrlParams) => boolean;
-              pre?: (request: NextRequestWithParams<T>) => MaybePromise<
-                  | boolean
-                  | {
-                        redirectTo: string | URL;
-                        statusCode?: number;
-                    }
-              >;
-          },
-          "domain" | "matcher"
-      >
+        {
+            /**
+             *
+             * The middleware to run if the requirements matches
+             */
+            handler: NextMiddlewareWithParams<T> | Middleware<T>[];
+            /**
+             *
+             * A function to match the hostname of the request
+             * or a regex to match the hostname
+             */
+            hostname?: RegExp | ((hostname: string) => boolean);
+
+            /**
+             *
+             * A regex or path-regexp to match the path
+             * This is the argument passed to `pathRegexp`
+             */
+            path?: PathMatcher;
+
+            /**
+             *
+             * A function to filter the path
+             * based on the params
+             */
+            filter?: (params: UrlParams) => boolean;
+
+            /**
+             * A function to run before the handler
+             * @returns true to continue, false to stop
+             * @returns `{ redirectTo: string | URL; statusCode?: number }` to redirect
+             */
+            pre?: (request: NextRequestWithParams<T>) => MaybePromise<
+                | boolean
+                | {
+                    redirectTo: string | URL;
+                    statusCode?: number;
+                }
+            >;
+        },
+        "hostname" | "path"
+    >
     | RedirectMatcher<T>;
 
 interface RedirectMatcher<T> {
-    matcher: PathMatcher;
-    guard?: (params: UrlParams) => boolean;
+    /**
+     *
+     * A regex or path-regexp to match the path
+     * This is the argument passed to `pathRegexp`
+     */
+    path: PathMatcher;
+
+    /**
+     *
+     * A function to filter the path
+     * based on the params
+     */
+    filter?: (params: UrlParams) => boolean;
+
+    /**
+     *
+     * A function that retuns the path to redirect to
+     */
     redirectTo: string | ((req: NextRequestWithParams<T>) => string);
+
+    /**
+     *
+     * If set to `true` add a query-param `origin` with the current path
+     * If set to a string, add a query-param with as key the value of the string, as value the current path
+     *
+     * @default false
+     *
+     * @example
+     * {
+     *    path: "/foo/bar",
+     *    redirectTo: "/baz",
+     *    includeOrigin: true,
+     * } // => /baz?origin=/foo/bar
+     *
+     * @example
+     * {
+     *    path: "/foo/bar",
+     *    redirectTo: "/baz",
+     *    includeOrigin: "redirected_from",
+     * } // => /baz?redirected_from=/foo/bar
+     */
     includeOrigin?: string | boolean;
 }
+
+export const Middleware = {
+    is: <T>(m: any): m is Middleware<T> =>
+        "handler" in m && ("hostname" in m || "path" in m),
+};
 
 export const RedirectMatcher = {
     is: <T>(middleware: Middleware<T>): middleware is RedirectMatcher<T> =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,7 +31,7 @@ interface FindOptions {
     path: string;
 }
 
-// find the middleware corrisponding to the path or domain
+// find the middleware corrisponding to the path or hostname
 export function findMiddleware<T>(
     middlewares: Middleware<T>[],
     { path, hostname }: FindOptions
@@ -50,7 +50,7 @@ export function findMiddleware<T>(
             return matches;
         }
 
-        // domain is always defined if matcher is not
+        // hostname is always defined if matcher is not
         return m.hostname instanceof RegExp
             ? m.hostname.test(hostname)
             : m.hostname?.(hostname);


### PR DESCRIPTION
This PR aims to improve the DX by renaming the keys of the `Middleware` type.

```diff
{
-     matcher: '/dashboard/:path'
+    path: '/dashboard/:path'
}
```

```diff
{
-    domain: /^app./
+    hostname: /^app./
}
```

- feat: key renamed
- tests: updated keys
- docs: updated examples
- chore: updated docs and comments
- chore: lockfile
